### PR TITLE
labeler: modify to use branch config rather than target branch (main)…

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+- pull_request
 
 jobs:
   triage:


### PR DESCRIPTION
When submitting a pull request that includes updates of the labeler action version and associated configuration files, using the pull_request_target event may result in a failed workflow.  This has to do with the mismatch between PR target branch and workflow configs / versions.

See https://github.com/actions/labeler?tab=readme-ov-file#updating-major-version-of-the-labeler for more details.

This change, made to the main branch prior to upgrade, prevents this issue.